### PR TITLE
Added ctrl_c() function

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -302,7 +302,9 @@ fn ctrl_c() -> bool {
     // event::poll() checks if there is an event ready to be handled
     // if you call event::read() without this it would halt the program until there is an event
     if let Ok(res) = event::poll(Duration::ZERO) {
-        if !res { return false }
+        if !res {
+            return false;
+        }
         // Check if the event read was of type event::Event::Key. We don't care about mouse and other events
         if let event::Event::Key(event) = event::read().unwrap() {
             // If the key pressed has the modifier CONTROL and the char of the key is 'c', i.e. CTRL+C


### PR DESCRIPTION
This is to fix issue #23: "enable_raw_mode disables SIGINT but library does not reimplement Ctrl+C handling "

When in raw mode, CTRL+C does not stop the program, but is instead sent to the stdin. Crossterm does not have a built in function that detects a CTRL+C, but it has an entire module for reading and handling events.
Using this module, we can see if there is an event ready to be handled and check if it is a CTRL+C event. 
To check if this is a CTRL+C event we need to check that the event was in fact a keyboard event, and that that event had the modifier CONTROL and the char 'C'. 