### PR TITLE
Removed atty crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,5 +8,4 @@ readme = "README.md"
 
 
 [dependencies]
-atty = "0.2.14"
 crossterm = "0.29.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-use atty::Stream;
 use crossterm::{
     ExecutableCommand,
     cursor::{self, MoveTo},
@@ -8,7 +7,7 @@ use crossterm::{
 
 use std::time::Duration;
 use std::{
-    io::{self, Write},
+    io::{self, IsTerminal, Write},
     sync::{
         Once,
         atomic::{AtomicU16, Ordering},
@@ -144,7 +143,7 @@ pub struct ProgressBar {
 
 impl ProgressBar {
     pub fn new(desc: &str, len: usize, size: usize) -> Self {
-        let term_mode = if !atty::is(Stream::Stdout) {
+        let term_mode = if !io::stdout().is_terminal() {
             TerminalMode::Headless
         } else {
             TerminalMode::Interactive


### PR DESCRIPTION
This is solve issue #32 Replace atty with std:io.isTerminal .
I call io::stdout to get a handle on the stdout, then check if that is a terminal