### PR TITLE
Add multi-distro CI workflow for Rustybar

### DIFF
--- a/.github/workflows/linux-distro-ci.yml
+++ b/.github/workflows/linux-distro-ci.yml
@@ -1,0 +1,55 @@
+name: Rustybar Linux Multi-Distro CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+
+jobs:
+  test-linux-distros:
+    name: Test on ${{ matrix.distro }}
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        distro:
+          - ubuntu:22.04
+          - debian:12
+          - fedora:39
+          - archlinux:latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Run tests inside ${{ matrix.distro }} container
+        uses: addnab/docker-run-action@v3
+        with:
+          image: ${{ matrix.distro }}
+          options: -v ${{ github.workspace }}:/work -w /work
+          run: |
+            set -e
+
+            echo "Running on $(cat /etc/os-release | grep PRETTY_NAME)"
+
+            # Install Rust & deps per distro
+            if command -v apt-get >/dev/null; then
+              apt-get update
+              apt-get install -y curl build-essential pkg-config libdbus-1-dev
+            elif command -v dnf >/dev/null; then
+              dnf install -y curl gcc make pkg-config dbus-devel
+            elif command -v pacman >/dev/null; then
+              pacman -Sy --noconfirm curl base-devel pkg-config dbus
+            fi
+
+            # Install Rust
+            curl https://sh.rustup.rs -sSf | sh -s -- -y
+            source $HOME/.cargo/env
+
+            rustc --version
+            cargo --version
+
+            # Build and test rustybar
+            cargo build --verbose
+            cargo test --verbose

--- a/.github/workflows/linux-distro-ci.yml
+++ b/.github/workflows/linux-distro-ci.yml
@@ -32,7 +32,6 @@ jobs:
             set -e
             echo "Running on $(grep PRETTY_NAME /etc/os-release)"
 
-            # Install dependencies per distro
             if command -v apt-get >/dev/null; then
               apt-get update
               apt-get install -y \
@@ -55,13 +54,11 @@ jobs:
                 dbus libxcb libx11 libxrandr
             fi
 
-            # Install Rust
             curl https://sh.rustup.rs -sSf | sh -s -- -y
-            source $HOME/.cargo/env
+            . $HOME/.cargo/env
 
             rustc --version
             cargo --version
 
-            # Build & test rustybar
             cargo build --verbose
             cargo test --verbose

--- a/.github/workflows/linux-distro-ci.yml
+++ b/.github/workflows/linux-distro-ci.yml
@@ -23,24 +23,36 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Run tests inside ${{ matrix.distro }} container
+      - name: Run build & tests inside ${{ matrix.distro }}
         uses: addnab/docker-run-action@v3
         with:
           image: ${{ matrix.distro }}
           options: -v ${{ github.workspace }}:/work -w /work
           run: |
             set -e
+            echo "Running on $(grep PRETTY_NAME /etc/os-release)"
 
-            echo "Running on $(cat /etc/os-release | grep PRETTY_NAME)"
-
-            # Install Rust & deps per distro
+            # Install dependencies per distro
             if command -v apt-get >/dev/null; then
               apt-get update
-              apt-get install -y curl build-essential pkg-config libdbus-1-dev
+              apt-get install -y \
+                curl \
+                build-essential \
+                pkg-config \
+                libdbus-1-dev \
+                libxcb-shape0-dev \
+                libxcb-xfixes0-dev \
+                libx11-dev \
+                libxrandr-dev \
+                ca-certificates
             elif command -v dnf >/dev/null; then
-              dnf install -y curl gcc make pkg-config dbus-devel
+              dnf install -y \
+                curl gcc make pkg-config \
+                dbus-devel libxcb-devel libX11-devel libXrandr-devel
             elif command -v pacman >/dev/null; then
-              pacman -Sy --noconfirm curl base-devel pkg-config dbus
+              pacman -Sy --noconfirm \
+                curl base-devel pkg-config \
+                dbus libxcb libx11 libxrandr
             fi
 
             # Install Rust
@@ -50,6 +62,6 @@ jobs:
             rustc --version
             cargo --version
 
-            # Build and test rustybar
+            # Build & test rustybar
             cargo build --verbose
             cargo test --verbose


### PR DESCRIPTION
**Solution for Issue: Add other linux distro in CI #34**
This workflow tests the Rustybar project on multiple Linux distributions using GitHub Actions. It sets up a CI pipeline for Ubuntu, Debian, Fedora, and Arch Linux.